### PR TITLE
Change swingSubdivision desc to correct value

### DIFF
--- a/docs/Transport.html
+++ b/docs/Transport.html
@@ -104,7 +104,7 @@ Tone.Transport.timeSignature; <span class="hljs-comment">//returns 3.5</span></p
 			<span id="title">.swingSubdivision</span>
 			<span class="type"><span class='paren'>{</span><a href='../docs/#types/Time'>Time</a><span class='paren'>}</span></span>
 			<div id="description"><p>Set the subdivision which the swing will be applied to. 
- The default values is a 16th note. Value must be less 
+ The default value is an 8th note. Value must be less 
  than a quarter note.</p>
 </div>
 		</div>


### PR DESCRIPTION
The default swingSubdivision for the Tone.Transport is an 8th note and not a 16th note.