### PR TITLE
update Music Blocks URL to current host

### DIFF
--- a/_data/demos.yaml
+++ b/_data/demos.yaml
@@ -107,7 +107,7 @@
   image : https://drive.google.com/thumbnail?id=1Z0tCdtCh6FQpSsnQb3jumDX54YsXy0FL&sz=w400-h400
 
 - title : Music Blocks
-  url : http://walterbender.github.io/musicblocks/
+  url : https://musicblocks.sugarlabs.org/
   image : https://drive.google.com/thumbnail?id=16sfehsMDyq10nj3xpG5rOc3OYheSTmjh&sz=w400-h400
 
 - title : zhredBoard


### PR DESCRIPTION
The host for music blocks has moved to sugarlabs.org
